### PR TITLE
Use channel mention instead of name in HoF embeds

### DIFF
--- a/commands/halloffame.js
+++ b/commands/halloffame.js
@@ -29,7 +29,7 @@ exports.run = async (bot, message, args, level) => {
 	} else {
 		HoF.addField('User', `${msg.member.nickname} (${msg.author.username})`, true);
 	};
-	HoF.addField('Channel', `${msg.channel.name}`, true)
+	HoF.addField('Channel', `${msg.channel}`, true)
 	if (msg.attachments.size == 0) {
 		HoF.addField('Message', `${msg}`)
 	} else {

--- a/events/messageReactionAdd.js
+++ b/events/messageReactionAdd.js
@@ -24,7 +24,7 @@ module.exports = async (bot, messageReaction, user) => {
 		} else {
 			HoF.addField('User', `${msg.member.nickname} (${msg.author.username})`, true);
 		};
-		HoF.addField('Channel', `${msg.channel.name}`, true)
+		HoF.addField('Channel', `${msg.channel}`, true)
 		if (msg.attachments.size == 0) {
 			HoF.addField('Message', `${msg}`)
 		} else {


### PR DESCRIPTION
Alternatively you could use `<#${msg.channel.id}>`, which the official client will format as a channel mention automagically.  
The main downside this has is that if the channel is later deleted, you'll no longer see the name of the channel that the message was from. The upside is that HoF embeds will update to respect channel name changes if/when they occur.